### PR TITLE
This commit fixes the wrong parameter of scp command when using the configBackup.

### DIFF
--- a/contrib/pgxc_ctl/config.c
+++ b/contrib/pgxc_ctl/config.c
@@ -922,7 +922,10 @@ verifyResource(void)
 		checkConfiguredAndSize(datanodeSlaveVars, "datanode slave");
 	}
 	if (anyConfigErrors)
+	{
 		elog(ERROR, "ERROR: Found fundamental configuration error.\n");
+		exit(1);
+	}
 	/*
 	 * --------------- Resource Conflict Check ---------------------
 	 */

--- a/contrib/pgxc_ctl/do_shell.c
+++ b/contrib/pgxc_ctl/do_shell.c
@@ -710,10 +710,10 @@ doConfigBackup(void)
 {
 	int rc;
 
-	rc = doImmediateRaw("ssh %s@%s mkdir -p %s;scp %s %s@%sp:%s",
+	rc = doImmediateRaw("ssh %s@%s mkdir -p %s;scp %s %s@%s:%s/%s",
 						sval(VAR_pgxcUser), sval(VAR_configBackupHost), sval(VAR_configBackupDir),
 						pgxc_ctl_config_path, sval(VAR_pgxcUser), sval(VAR_configBackupHost),
-						sval(VAR_configBackupFile));
+						sval(VAR_configBackupDir), sval(VAR_configBackupFile));
 	return(rc);
 }
 

--- a/contrib/pgxc_ctl/pgxc_ctl_bash.c
+++ b/contrib/pgxc_ctl/pgxc_ctl_bash.c
@@ -615,7 +615,7 @@ char *pgxc_ctl_conf_prototype[] = {
 "#---- Datanodes ---------------------",
 "",
 "#---- Shortcuts --------------",
-"dnMstrDi=$HOME/pgxc/nodes/dn_master",
+"dnMstrDir=$HOME/pgxc/nodes/dn_master",
 "dnSlvDir=$HOME/pgxc/nodes/dn_slave",
 "dnALDir=$HOME/pgxc/nodes/datanode_archlog",
 "",


### PR DESCRIPTION
There is a bug in pgxc_ctl when using the configBackup. The reason is
that the parameter of scp command used to copy config file is a little
wrong.  I fix the bug and test it. And everything is OK.
