### PR TITLE
This commit fixes the bug for issue #103.

### DIFF
--- a/contrib/pgxc_ctl/config.c
+++ b/contrib/pgxc_ctl/config.c
@@ -922,7 +922,10 @@ verifyResource(void)
 		checkConfiguredAndSize(datanodeSlaveVars, "datanode slave");
 	}
 	if (anyConfigErrors)
+	{
 		elog(ERROR, "ERROR: Found fundamental configuration error.\n");
+		exit(1);
+	}
 	/*
 	 * --------------- Resource Conflict Check ---------------------
 	 */

--- a/contrib/pgxc_ctl/config.c
+++ b/contrib/pgxc_ctl/config.c
@@ -849,6 +849,7 @@ verifyResource(void)
 							VAR_gtmProxyServers, 
 							VAR_gtmProxyPorts, 
 							VAR_gtmProxyDirs, 
+							VAR_gtmPxySpecificExtraConfig,
 							NULL};
 	char *coordMasterVars[] = {VAR_coordNames, 
 							   VAR_coordPorts, 
@@ -856,6 +857,8 @@ verifyResource(void)
 							   VAR_coordMasterServers,
 							   VAR_coordMasterDirs, 
 							   VAR_coordMaxWALSenders, 
+							   VAR_coordSpecificExtraConfig,
+							   VAR_coordSpecificExtraPgHba,
 							   NULL};
 	char *coordSlaveVars[] = {VAR_coordNames, 
 							  VAR_coordSlaveServers, 
@@ -877,6 +880,8 @@ verifyResource(void)
 								  VAR_datanodeMasterServers,
 								  VAR_datanodeMasterDirs, 
 								  VAR_datanodeMaxWALSenders, 
+								  VAR_datanodeSpecificExtraConfig,
+								  VAR_datanodeSpecificExtraPgHba,
 								  NULL};
 	char *datanodeSlaveVars[] = {VAR_datanodeNames,
 								 VAR_datanodeSlaveServers,

--- a/contrib/pgxc_ctl/do_shell.c
+++ b/contrib/pgxc_ctl/do_shell.c
@@ -710,10 +710,10 @@ doConfigBackup(void)
 {
 	int rc;
 
-	rc = doImmediateRaw("ssh %s@%s mkdir -p %s;scp %s %s@%sp:%s",
+	rc = doImmediateRaw("ssh %s@%s mkdir -p %s;scp %s %s@%s:%s/%s",
 						sval(VAR_pgxcUser), sval(VAR_configBackupHost), sval(VAR_configBackupDir),
 						pgxc_ctl_config_path, sval(VAR_pgxcUser), sval(VAR_configBackupHost),
-						sval(VAR_configBackupFile));
+						sval(VAR_configBackupDir), sval(VAR_configBackupFile));
 	return(rc);
 }
 

--- a/contrib/pgxc_ctl/pgxc_ctl_bash.c
+++ b/contrib/pgxc_ctl/pgxc_ctl_bash.c
@@ -615,7 +615,7 @@ char *pgxc_ctl_conf_prototype[] = {
 "#---- Datanodes ---------------------",
 "",
 "#---- Shortcuts --------------",
-"dnMstrDi=$HOME/pgxc/nodes/dn_master",
+"dnMstrDir=$HOME/pgxc/nodes/dn_master",
 "dnSlvDir=$HOME/pgxc/nodes/dn_slave",
 "dnALDir=$HOME/pgxc/nodes/datanode_archlog",
 "",

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1160,11 +1160,10 @@ BuildRelationDistributionNodes(List *nodes, int *numnodes)
 {
 	Oid *nodeoids;
 	ListCell *item;
-
 	*numnodes = 0;
 
-	/* Allocate once enough space for OID array */
-	nodeoids = (Oid *) palloc0(NumDataNodes * sizeof(Oid));
+	/* Allocate once enough space for OID array */	  
+	nodeoids = (Oid *) palloc0(list_length(nodes) * sizeof(Oid));
 
 	/* Do process for each node name */
 	foreach(item, nodes)

--- a/src/backend/pgxc/pool/poolmgr.c
+++ b/src/backend/pgxc/pool/poolmgr.c
@@ -2364,8 +2364,6 @@ PoolerLoop(void)
 			nfds = Max(nfds, sockfd);
 		}
 
-		/* wait for event */
-		retval = select(nfds + 1, &rfds, NULL, NULL, NULL);
 		if (shutdown_requested)
 		{
 			for (i = agentCount - 1; i >= 0; i--)
@@ -2381,6 +2379,9 @@ PoolerLoop(void)
 			close(server_fd);
 			exit(0);
 		}
+		/* wait for event */
+		retval = select(nfds + 1, &rfds, NULL, NULL, NULL);
+
 		if (retval > 0)
 		{
 			/*


### PR DESCRIPTION
Configuration errors in pgxc_ctl.conf may cause segment fault.  When the element number of coordSpecificExtraConfig/coordSpecificExtraPgHba is less than coordinator master/slave, pgxc_ctl process may get a segment fault. And gtm_proxy/datanode have the same error.  So, it is necessary
for pgxc_ctl process to verify the configuration before startup.
