### PR TITLE
This commit fixes the bug for issue #103

### DIFF
--- a/contrib/pgxc_ctl/config.c
+++ b/contrib/pgxc_ctl/config.c
@@ -849,6 +849,7 @@ verifyResource(void)
 							VAR_gtmProxyServers, 
 							VAR_gtmProxyPorts, 
 							VAR_gtmProxyDirs, 
+							VAR_gtmPxySpecificExtraConfig,
 							NULL};
 	char *coordMasterVars[] = {VAR_coordNames, 
 							   VAR_coordPorts, 
@@ -856,6 +857,8 @@ verifyResource(void)
 							   VAR_coordMasterServers,
 							   VAR_coordMasterDirs, 
 							   VAR_coordMaxWALSenders, 
+							   VAR_coordSpecificExtraConfig,
+							   VAR_coordSpecificExtraPgHba,
 							   NULL};
 	char *coordSlaveVars[] = {VAR_coordNames, 
 							  VAR_coordSlaveServers, 
@@ -877,6 +880,8 @@ verifyResource(void)
 								  VAR_datanodeMasterServers,
 								  VAR_datanodeMasterDirs, 
 								  VAR_datanodeMaxWALSenders, 
+								  VAR_datanodeSpecificExtraConfig,
+								  VAR_datanodeSpecificExtraPgHba,
 								  NULL};
 	char *datanodeSlaveVars[] = {VAR_datanodeNames,
 								 VAR_datanodeSlaveServers,


### PR DESCRIPTION
Configuration errors in pgxc_ctl.conf may cause segment fault. When the
element number of coordSpecificExtraConfig/coordSpecificExtraPgHba is
less than coordinator master/slave, pgxc_ctl process may get a segment
fault. And gtm_proxy/datanode have the same error. So, it is necessary
for pgxc_ctl process to verify the configuration before startup.
