### PR TITLE
Refactor code to send MSG_TXN_START_PREPARED message.

### DIFF
--- a/src/include/gtm/gtm_client.h
+++ b/src/include/gtm/gtm_client.h
@@ -182,7 +182,7 @@ int abort_transaction(GTM_Conn *conn, GlobalTransactionId gxid);
 int bkup_abort_transaction(GTM_Conn *conn, GlobalTransactionId gxid);
 int start_prepared_transaction(GTM_Conn *conn, GlobalTransactionId gxid, char *gid,
 							   char *nodestring);
-int backup_start_prepared_transaction(GTM_Conn *conn, GTM_TransactionHandle txn, char *gid,
+int backup_start_prepared_transaction(GTM_Conn *conn, GlobalTransactionId gxid, char *gid,
 									  char *nodestring);
 int prepare_transaction(GTM_Conn *conn, GlobalTransactionId gxid);
 int bkup_prepare_transaction(GTM_Conn *conn, GlobalTransactionId gxid);


### PR DESCRIPTION
Move logic to a single place to send both MSG_TXN_START_PREPARED and MSG_BKUP_TXN_START_PREPARED. Also, make sure we send down the gxid and not the handle to the standby since handles do not work across primary and standby
