### PR TITLE
This commit enhances the setting of PGXCNODE_CANCEL_DALAY value from

### DIFF
--- a/src/backend/pgxc/pool/pgxcnode.c
+++ b/src/backend/pgxc/pool/pgxcnode.c
@@ -76,6 +76,9 @@ static PGXCNodeHandle *co_handles = NULL;
 int			NumDataNodes;
 int 		NumCoords;
 
+/* Cancel Delay duration --> set by GUC */
+int			pgxcnode_cancel_delay = 10;
+
 static void pgxc_node_init(PGXCNodeHandle *handle, int sock);
 static void pgxc_node_free(PGXCNodeHandle *handle);
 static void pgxc_node_all_free(void);
@@ -876,12 +879,12 @@ cancel_query(void)
 		 * Hack to wait a moment to cancel requests are processed in other nodes.
 		 * If we send a new query to nodes before cancel requests get to be
 		 * processed, the query will get unanticipated failure.
-		 * As we have no way to know when to the request processed, we can't not
-		 * wait an experimental duration (10ms).
+		 * As we have no way to know when to the request processed,
+		 * and because this dulation depends upon the platform and the environment,
+		 * this value is now moved to GUC (pgxc_cancel_delay) parameter.
 		 */
-#if PGXC_CANCEL_DELAY > 0
-		pg_usleep(PGXC_CANCEL_DELAY * 1000);
-#endif
+	if (pgxcnode_cancel_delay > 0)
+		pg_usleep(pgxcnode_cancel_delay * 1000);
 }
 /*
  * This method won't return until all network buffers are empty

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -65,6 +65,7 @@
 #include "optimizer/pgxcplan.h"
 #include "pgxc/poolmgr.h"
 #include "pgxc/nodemgr.h"
+#include "pgxc/pgxcnode.h"
 #include "pgxc/xc_maintenance_mode.h"
 #endif
 #include "postmaster/autovacuum.h"
@@ -2606,6 +2607,16 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&MaxCoords,
 		16, 2, 65535,
+		NULL, NULL, NULL
+	},
+	{
+		{"pgxcnode_cancel_delay", PGC_USERSET, DATA_NODES,
+			gettext_noop("Cancel deay dulation at the coordinator."),
+			NULL,
+			GUC_UNIT_MS
+		},
+		&pgxcnode_cancel_delay,
+		10, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 #endif

--- a/src/include/pgxc/pgxcnode.h
+++ b/src/include/pgxc/pgxcnode.h
@@ -24,7 +24,6 @@
 
 #define NO_SOCKET -1
 
-#define PGXCNODE_CANCEL_DELAY 10	/* Cancel delay duration in millisecond */
 
 /* Connection to Datanode maintained by Pool Manager */
 typedef struct PGconn NODE_CONNECTION;
@@ -194,5 +193,8 @@ extern char get_message(PGXCNodeHandle *conn, int *len, char **msg);
 extern void add_error_message(PGXCNodeHandle * handle, const char *message);
 
 extern Datum pgxc_execute_on_nodes(int numnodes, Oid *nodelist, char *query);
+
+/* New GUC to store delay value of cancel delay dulation in millisecond */
+extern int pgxcnode_cancel_delay;
 
 #endif /* PGXCNODE_H */


### PR DESCRIPTION
This commit relates to PGXC tests, especially regression.  In regression, many statements are intentionally cancelled.   Because this cancellation has to propagate to all the relevant nodes and there's no way to wait until such cancelation propagated, there was 10msec delay in the core.   This does not work sometimes, especially in slow platform and environment.   In production, with proper platform, this delay can be much shorter.

I believe this works in testing XC in slower platform/environment.   Because it does not affect current setups of older releases, I'd like to port this to 1.2, and hopefully 1.1 too.

Following is the commit message.

fixed 10msec to GUC setups.  Still the default value is 10ms but
readonable value depends upon platform and environment.

So this setting was moved to GUC, pgxcnode_cancel_value.

You can specify this value in millisecond unit.  Larger value
setting is prefrered for slower platform/environment.

```
modified:   src/backend/pgxc/pool/pgxcnode.c
modified:   src/backend/utils/misc/guc.c
modified:   src/include/pgxc/pgxcnode.h
```
