### PR TITLE
Fix pooler dead lock caused by DDL, #142

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3986,23 +3986,24 @@ PostgresMain(int argc, char *argv[],
 	xc_lockForBackupKey1 = Int32GetDatum(XC_LOCK_FOR_BACKUP_KEY_1);
 	xc_lockForBackupKey1 = Int32GetDatum(XC_LOCK_FOR_BACKUP_KEY_2);
 
-	/* If this postmaster is launched from another Coord, do not initialize handles. skip it */
+	/* If this postgres is launched from another Coord, do not initialize handles. skip it */
 	if (!am_walsender && IS_PGXC_COORDINATOR && !IsPoolHandle())
 	{
 		CurrentResourceOwner = ResourceOwnerCreate(NULL, "ForPGXCNodes");
 
 		InitMultinodeExecutor(false);
-
-		pool_handle = GetPoolManagerHandle();
-		if (pool_handle == NULL)
+		if (!IsConnFromCoord())
 		{
-			ereport(ERROR,
-				(errcode(ERRCODE_IO_ERROR),
-				 errmsg("Can not connect to pool manager")));
-			return STATUS_ERROR;
+			pool_handle = GetPoolManagerHandle();
+			if (pool_handle == NULL)
+			{
+				ereport(ERROR,
+					(errcode(ERRCODE_IO_ERROR),
+					 errmsg("Can not connect to pool manager")));
+			}
+			/* Pooler initialization has to be made before ressource is released */
+			PoolManagerConnect(pool_handle, dbname, username, session_options());
 		}
-		/* Pooler initialization has to be made before ressource is released */
-		PoolManagerConnect(pool_handle, dbname, username, session_options());
 
 		ResourceOwnerRelease(CurrentResourceOwner, RESOURCE_RELEASE_BEFORE_LOCKS, true, true);
 		ResourceOwnerRelease(CurrentResourceOwner, RESOURCE_RELEASE_LOCKS, true, true);

--- a/src/gtm/proxy/proxy_thread.c
+++ b/src/gtm/proxy/proxy_thread.c
@@ -388,10 +388,11 @@ GTMProxy_ThreadAddConnection(GTMProxy_ConnectionInfo *conninfo)
 	 * response. We use that information to route the response back to the
 	 * approrpiate connection
 	 */
-	con_idx = thrinfo->thr_conn_count++;
+	con_idx = thrinfo->thr_conn_count;
 	conninfo->con_id = con_id;
 	thrinfo->thr_conid2idx[con_id] = con_idx;
 	thrinfo->thr_all_conns[con_idx] = conninfo;
+	thrinfo->thr_conn_count++;
 	elog(DEBUG5, "Assigned a connection id to new connection: id = %d, index = %d", con_id, con_idx);
 
 	/*


### PR DESCRIPTION
This issue was cause by DDL from more than one coords, all process got stuck in startup status.So the fix is we just don't get pooler connection when the connetction is from another coord and I am also a coord. In pgxc, connetcion inter coords only needed in DDL, so we can avoid DDL deadlocks from different coords.
