### PR TITLE
fix issue #142

### DIFF
--- a/src/backend/pgxc/pool/poolutils.c
+++ b/src/backend/pgxc/pool/poolutils.c
@@ -237,6 +237,11 @@ CleanConnection(CleanConnStmt *stmt)
 		return;
 	}
 
+	if (!IsPoolHandle())
+	{
+		PoolManagerReconnect();
+	}
+	
 	/*
 	 * FORCE is activated,
 	 * Send a SIGTERM signal to all the processes and take a lock on Pooler
@@ -349,7 +354,11 @@ DropDBCleanConnection(char *dbname)
 	if (!pg_database_ownercheck(get_database_oid(dbname, true), GetUserId()))
 		aclcheck_error(ACLCHECK_NOT_OWNER, ACL_KIND_DATABASE,
 					   dbname);
-
+	if (!IsPoolHandle())
+	{
+		PoolManagerReconnect();
+	}
+	
 	PoolManagerCleanConnection(dn_list, co_list, dbname, NULL);
 
 	/* Clean up memory */

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3994,23 +3994,24 @@ PostgresMain(int argc, char *argv[],
 	xc_lockForBackupKey1 = Int32GetDatum(XC_LOCK_FOR_BACKUP_KEY_1);
 	xc_lockForBackupKey1 = Int32GetDatum(XC_LOCK_FOR_BACKUP_KEY_2);
 
-	/* If this postmaster is launched from another Coord, do not initialize handles. skip it */
+	/* If this postgres is launched from another Coord, do not initialize handles. skip it */
 	if (!am_walsender && IS_PGXC_COORDINATOR && !IsPoolHandle())
 	{
 		CurrentResourceOwner = ResourceOwnerCreate(NULL, "ForPGXCNodes");
 
 		InitMultinodeExecutor(false);
-
-		pool_handle = GetPoolManagerHandle();
-		if (pool_handle == NULL)
+		if (!IsConnFromCoord())
 		{
-			ereport(ERROR,
-				(errcode(ERRCODE_IO_ERROR),
-				 errmsg("Can not connect to pool manager")));
-			return STATUS_ERROR;
+			pool_handle = GetPoolManagerHandle();
+			if (pool_handle == NULL)
+			{
+				ereport(ERROR,
+					(errcode(ERRCODE_IO_ERROR),
+					 errmsg("Can not connect to pool manager")));
+			}
+			/* Pooler initialization has to be made before ressource is released */
+			PoolManagerConnect(pool_handle, dbname, username, session_options());
 		}
-		/* Pooler initialization has to be made before ressource is released */
-		PoolManagerConnect(pool_handle, dbname, username, session_options());
 
 		ResourceOwnerRelease(CurrentResourceOwner, RESOURCE_RELEASE_BEFORE_LOCKS, true, true);
 		ResourceOwnerRelease(CurrentResourceOwner, RESOURCE_RELEASE_LOCKS, true, true);


### PR DESCRIPTION
In coord, if a session is connected from another coord, unless some pooler utility command, no need connect to pooler, because only DDL cause coord connecting to coord, but connection end in coord in this case.So just avoid connecting to pooler in coord when it is from another coord, and connect to pooler just running pooler utililty to avoid dead lock among poolers.
