### PR TITLE
patch to  issue 75

### DIFF
--- a/src/backend/optimizer/plan/pgxcplan.c
+++ b/src/backend/optimizer/plan/pgxcplan.c
@@ -2541,6 +2541,7 @@ pgxc_FQS_planner(Query *query, int cursorOptions, ParamListInfo boundParams)
 	PlannerInfo		*root;
 	ExecNodes		*exec_nodes;
 	Plan			*top_plan;
+
 	/* Try by-passing standard planner, if fast query shipping is enabled */
 	if (!enable_fast_query_shipping)
 		return NULL;
@@ -2604,7 +2605,6 @@ pgxc_FQS_planner(Query *query, int cursorOptions, ParamListInfo boundParams)
 	 * through set_plan_references().
 	 */
 	top_plan = set_plan_references(root, top_plan);
-             
 	/* build the PlannedStmt result */
 	result = makeNode(PlannedStmt);
 	/* Try and set what we can, rest must have been zeroed out by makeNode() */

--- a/src/backend/optimizer/plan/pgxcplan.c
+++ b/src/backend/optimizer/plan/pgxcplan.c
@@ -2639,13 +2639,25 @@ pgxc_FQS_create_remote_plan(Query *query, ExecNodes *exec_nodes, bool is_exec_di
 	StringInfoData	buf;
 	RangeTblEntry	*dummy_rte;
 	List			*collected_rtable;
-
+	List			*junk_tlist = NIL;
+	ListCell		*cell;
+	TargetEntry     *currentTle ; 
 	/* EXECUTE DIRECT statements have their RemoteQuery node already built when analyzing */
 	if (is_exec_direct)
 	{
 		Assert(IsA(query->utilityStmt, RemoteQuery));
 		query_step = (RemoteQuery *)query->utilityStmt;
 		query->utilityStmt = NULL;
+		/* Remove the junk TargetEntry */
+		foreach(cell, query->targetList) {
+			currentTle = (TargetEntry*)lfirst(cell);
+			if (currentTle->resjunk) {
+   				junk_tlist = lappend(junk_tlist, currentTle);
+			}
+		}
+		if (junk_tlist != NIL) {
+			query->targetList = list_difference(query->targetList, junk_tlist);
+		}
 	}
 	else
 	{

--- a/src/backend/optimizer/plan/pgxcplan.c
+++ b/src/backend/optimizer/plan/pgxcplan.c
@@ -2605,6 +2605,7 @@ pgxc_FQS_planner(Query *query, int cursorOptions, ParamListInfo boundParams)
 	 * through set_plan_references().
 	 */
 	top_plan = set_plan_references(root, top_plan);
+
 	/* build the PlannedStmt result */
 	result = makeNode(PlannedStmt);
 	/* Try and set what we can, rest must have been zeroed out by makeNode() */


### PR DESCRIPTION
For this issue, when user run SQL such as "SELECT relkind FROM pg_class GROUP BY relname, relkind" on datanode directly, pg_xc will create a remote query plan. The targetlist and base_tlist of the plan node should match the result columns returned from datanode. 
Currently, for this case, pgxc planner will create targetlist/base_tlist with 2 items (the first is a junk TargetEntry and the second item is the one we need), which does not match the results from datanode. The planner need to remove the junk TargetEntry. 

And on the other side, for issue 54, it seems planner does not create proper targetlist and base_tlist for agg node, I will try to fix it 
