### PR TITLE
ticket  for issue 77

### DIFF
--- a/src/backend/optimizer/util/pgxcship.c
+++ b/src/backend/optimizer/util/pgxcship.c
@@ -1479,7 +1479,7 @@ pgxc_find_dist_equijoin_qual(List *dist_vars1, List *dist_vars2, Node *quals)
 		else if (IsA(lsecond(op->args), RelabelType) &&
 				IsA(((RelabelType *)lsecond(op->args))->arg, Var))
 		{
-			lvar = (Var *)((RelabelType *)lsecond(op->args))->arg;
+			rvar = (Var *)((RelabelType *)lsecond(op->args))->arg;
 		}
 		else
 			continue;

--- a/src/backend/optimizer/util/pgxcship.c
+++ b/src/backend/optimizer/util/pgxcship.c
@@ -1448,8 +1448,8 @@ pgxc_find_dist_equijoin_qual(List *dist_vars1, List *dist_vars2, Node *quals)
 	{
 		Expr *qual_expr = (Expr *)lfirst(qcell);
 		OpExpr *op;
-		Var *lvar = NULL;
-		Var *rvar = NULL;
+		Var *lvar;
+		Var *rvar;
 
 		if (!IsA(qual_expr, OpExpr))
 			continue;

--- a/src/backend/optimizer/util/pgxcship.c
+++ b/src/backend/optimizer/util/pgxcship.c
@@ -1459,7 +1459,7 @@ pgxc_find_dist_equijoin_qual(List *dist_vars1, List *dist_vars2, Node *quals)
 			continue;
 
 		/*
-		 * Check if both operands are Vars, if not check next expression */
+		 * Check if operands are Vars or RelableType, if not check next expression */
 		if (IsA(linitial(op->args), Var))
 		{
 			lvar = (Var *)linitial(op->args);

--- a/src/backend/optimizer/util/pgxcship.c
+++ b/src/backend/optimizer/util/pgxcship.c
@@ -1468,7 +1468,7 @@ pgxc_find_dist_equijoin_qual(List *dist_vars1, List *dist_vars2, Node *quals)
 					IsA(((RelabelType *)linitial(op->args))->arg, Var))
 		{
 			lvar = (Var *)((RelabelType *)linitial(op->args))->arg;
-        } 
+		} 
 		else
 			continue;
 

--- a/src/backend/optimizer/util/pgxcship.c
+++ b/src/backend/optimizer/util/pgxcship.c
@@ -1464,7 +1464,8 @@ pgxc_find_dist_equijoin_qual(List *dist_vars1, List *dist_vars2, Node *quals)
 		{
 			lvar = (Var *)linitial(op->args);
 		}
-		else if (IsA(linitial(op->args), RelabelType))
+		else if (IsA(linitial(op->args), RelabelType) &&
+					IsA(((RelabelType *)linitial(op->args))->arg, Var))
 		{
 			lvar = (Var *)((RelabelType *)linitial(op->args))->arg;
         } 
@@ -1475,7 +1476,8 @@ pgxc_find_dist_equijoin_qual(List *dist_vars1, List *dist_vars2, Node *quals)
 		{
 			rvar = (Var *)lsecond(op->args);
 		}
-		else if (IsA(lsecond(op->args), RelabelType))
+		else if (IsA(lsecond(op->args), RelabelType) &&
+				IsA(((RelabelType *)lsecond(op->args))->arg, Var))
 		{
 			lvar = (Var *)((RelabelType *)lsecond(op->args))->arg;
 		}

--- a/src/backend/optimizer/util/pgxcship.c
+++ b/src/backend/optimizer/util/pgxcship.c
@@ -1448,8 +1448,8 @@ pgxc_find_dist_equijoin_qual(List *dist_vars1, List *dist_vars2, Node *quals)
 	{
 		Expr *qual_expr = (Expr *)lfirst(qcell);
 		OpExpr *op;
-		Var *lvar;
-		Var *rvar;
+		Var *lvar = NULL;
+		Var *rvar = NULL;
 
 		if (!IsA(qual_expr, OpExpr))
 			continue;
@@ -1460,10 +1460,24 @@ pgxc_find_dist_equijoin_qual(List *dist_vars1, List *dist_vars2, Node *quals)
 
 		/*
 		 * Check if both operands are Vars, if not check next expression */
-		if (IsA(linitial(op->args), Var) && IsA(lsecond(op->args), Var))
+		if (IsA(linitial(op->args), Var))
 		{
 			lvar = (Var *)linitial(op->args);
+		}
+		else if (IsA(linitial(op->args), RelabelType))
+		{
+			lvar = (Var *)((RelabelType *)linitial(op->args))->arg;
+        } 
+		else
+			continue;
+
+		if (IsA(lsecond(op->args), Var))
+		{
 			rvar = (Var *)lsecond(op->args);
+		}
+		else if (IsA(lsecond(op->args), RelabelType))
+		{
+			lvar = (Var *)((RelabelType *)lsecond(op->args))->arg;
 		}
 		else
 			continue;


### PR DESCRIPTION
For this issue, the planner will fail to find equijoin conditions against the distributed columns ( in pgxc_find_dist_equijoin_qual function of src/backend/optimizer/util/pgxcship.c), so planner find the join can not be shipped to datanodes .
In pgxc_find_dist_equijoin_qual function, it will check the element in the quals list as following: if the element is OpExpr and with 2 args and both arg are Var  and the args are the distributed columns and  the arg type is same and is joinable, it will return this element as the equijoin condition. If does not find, return NULL.
However, for this issue, the quals list has just one element: A.id = B.id, it is OpExr and with 2 args, but the args are not Var but RelableType, so it fails.
We need the take into account this, since in order to cast data, pg will make  RelableType for Var when transform parse tree to Query.
