### PR TITLE
fix some warning during complation

### DIFF
--- a/src/backend/catalog/pgxc_class.c
+++ b/src/backend/catalog/pgxc_class.c
@@ -12,6 +12,7 @@
 #include "postgres.h"
 
 #include "access/heapam.h"
+#include "access/htup_details.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -92,7 +92,9 @@ static void ExplainIndexScanDetails(Oid indexid, ScanDirection indexorderdir,
 static void ExplainScanTarget(Scan *plan, ExplainState *es);
 static void ExplainModifyTarget(ModifyTable *plan, ExplainState *es);
 static void ExplainTargetRel(Plan *plan, Index rti, ExplainState *es);
+#ifndef PGXC
 static void show_modifytable_info(ModifyTableState *mtstate, ExplainState *es);
+#endif
 static void ExplainMemberNodes(List *plans, PlanState **planstates,
 				   List *ancestors, ExplainState *es);
 static void ExplainSubPlans(List *plans, List *ancestors,
@@ -2101,6 +2103,7 @@ ExplainTargetRel(Plan *plan, Index rti, ExplainState *es)
 	}
 }
 
+#ifndef PGXC
 /*
  * Show extra information for a ModifyTable node
  */
@@ -2128,6 +2131,7 @@ show_modifytable_info(ModifyTableState *mtstate, ExplainState *es)
 										 es);
 	}
 }
+#endif /* PGXC */
 
 /*
  * Explain the constituent plans of a ModifyTable, Append, MergeAppend,

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -411,7 +411,7 @@ pgxc_fill_matview_by_copy(DestReceiver *mv_dest, bool skipdata, int operation,
 							TupleDesc tupdesc)
 {
 	CopyState	cstate;
-	Relation	mv_rel;
+	Relation	mv_rel = NULL;
 	TupleDesc	tupDesc;
 	Datum		*values;
 	bool		*isnulls;

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -677,15 +677,15 @@ nextval_internal(Oid relid)
 	Page		page;
 	HeapTupleData seqtuple;
 	Form_pg_sequence seq;
-	int64		incby,
-				maxv,
-				minv,
+	int64		incby = 0,
+				maxv = 0,
+				minv = 0,
 				cache,
 				log,
 				fetch,
-				last;
+				last = 0;
 	int64		result,
-				next,
+				next = 0,
 				rescnt = 0;
 	bool		logit = false;
 #ifdef PGXC

--- a/src/backend/optimizer/plan/pgxcplan.c
+++ b/src/backend/optimizer/plan/pgxcplan.c
@@ -1072,7 +1072,7 @@ pgxc_build_dml_statement(PlannerInfo *root, CmdType cmdtype,
 	bool			ctid_found = false;
 	bool			node_id_found = false;
 	int				col_att = 0;
-	int				ctid_param_num;
+	int				ctid_param_num = 0;
 	ListCell		*lc;
 	bool			can_use_pk_for_rep_change = false;
 	int16			*indexed_col_numbers = NULL;

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -66,6 +66,7 @@
 #include "utils/datetime.h"
 #include "utils/numeric.h"
 #include "utils/xml.h"
+#include "miscadmin.h"
 
 
 /*

--- a/src/backend/pgxc/nodemgr/groupmgr.c
+++ b/src/backend/pgxc/nodemgr/groupmgr.c
@@ -14,6 +14,7 @@
 #include "miscadmin.h"
 
 #include "access/heapam.h"
+#include "access/htup_details.h"
 #include "catalog/catalog.h"
 #include "catalog/indexing.h"
 #include "catalog/pg_type.h"

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4532,7 +4532,7 @@ PostgresMain(int argc, char *argv[],
 				SetGlobalSnapshotData(xmin, xmax, xcnt, xip);
 				/* Latest Snashot data for update visibility */
 				setSyncGXID();
-				setLatestGTMSnapshot(xmin, xmax, xcnt, xip);
+				setLatestGTMSnapshot(xmin, xmax, xcnt, (GlobalTransactionId *) xip);
 				break;
 
 			case 't':			/* timestamp */

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -5807,8 +5807,8 @@ get_variable(Var *var, int levelsup, bool istoplevel, deparse_context *context)
 	AttrNumber	attnum;
 	int			netlevelsup;
 	deparse_namespace *dpns;
-	deparse_columns *colinfo;
-	char	   *refname;
+	deparse_columns *colinfo = NULL;
+	char	   *refname = NULL;
 	char	   *attname;
 
 	/* Find appropriate nesting depth */

--- a/src/gtm/client/fe-protocol.c
+++ b/src/gtm/client/fe-protocol.c
@@ -570,7 +570,7 @@ gtmpqParseSuccess(GTM_Conn *conn, GTM_Result *result)
 			}
 
 			result->gr_resdata.grd_seq_list.seq =
-						(GTM_SeqInfo **)malloc(sizeof(GTM_SeqInfo) *
+						(GTM_SeqInfo *)malloc(sizeof(GTM_SeqInfo) *
 											   result->gr_resdata.grd_seq_list.seq_count);
 
 			for (i = 0 ; i < result->gr_resdata.grd_seq_list.seq_count; i++)


### PR DESCRIPTION
First commit fixes warnings about implicit declarations of functions heap_modify_tuple, heap_modify_tuple, superuser.
Second fixes warning fix but not used function show_modifytable_info() when we compile coordinator part of XC.
Third fixes uninitialized variables by setting 0 or NULL values
Latest fixes warnings type casts. Please check function's signature and types when its used.

Hope, that is will be useful for Postgres-XC.
