### PR TITLE
This commit fixes the bug for pgxc_ctl monitor command.

### DIFF
--- a/contrib/pgxc_ctl/monitor.c
+++ b/contrib/pgxc_ctl/monitor.c
@@ -384,7 +384,7 @@ do_monitor_command(char *line)
 		if (!GetToken() || TestToken("all"))
 		{
 			monitor_datanode_master(aval(VAR_datanodeNames));
-			if (isVarYes(VAR_coordSlave))
+			if (isVarYes(VAR_datanodeSlave))
 				monitor_datanode_slave(aval(VAR_datanodeNames));
 		}
 		else if (TestToken("master"))


### PR DESCRIPTION
When monitoring the datanode status, the datanode slaves are missing.
