### PR TITLE
ticket  for issue 308

### DIFF
--- a/src/gtm/common/Makefile
+++ b/src/gtm/common/Makefile
@@ -17,7 +17,7 @@ LIBS += $(PTHREAD_LIBS)
 include $(top_srcdir)/src/backend/common.mk
 
 OBJS = gtm_utils.o gtm_lock.o gtm_serialize.o gtm_serialize_debug.o \
-	aset.o assert.o elog.o mcxt.o stringinfo.o gtm_list.o
+	aset.o assert.o elog.o mcxt.o stringinfo.o gtm_list.o gtm_bitmapset.o
 
 all: libgtmcommon.a
 

--- a/src/gtm/common/gtm_bitmapset.c
+++ b/src/gtm/common/gtm_bitmapset.c
@@ -291,13 +291,12 @@ gtm_bms_first_member(gtm_Bitmapset *a)
 void
 gtm_bms_reset(gtm_Bitmapset *a)
 {
-	int			shortlen;
 	int			i;
 
 	if (a == NULL)
-		return NULL;
+		return ;
 	for (i = 0; i < a->nwords; i++)
 		a->words[i] &= 0;
-	return a;
+	return ;
 }
 

--- a/src/gtm/common/gtm_bitmapset.c
+++ b/src/gtm/common/gtm_bitmapset.c
@@ -1,0 +1,225 @@
+/*-------------------------------------------------------------------------
+ *
+ * gtm_bitmapset.c
+ * bitmapset of GTM
+ *
+ * Portions Copyright (c) 1996-2010, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ * Portions Copyright (c) 2010-2012 Postgres-XC Development Group
+ *
+ *
+ * IDENTIFICATION
+ *      src/gtm/common/gtm_bitmapset.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "gtm/elog.h"
+#include "gtm/gtm.h"
+
+#define GTM_WORDNUM(x)  ((x) / GTM_BITS_PER_BITMAPWORD)
+#define GTM_BITNUM(x)   ((x) % GTM_BITS_PER_BITMAPWORD)
+
+#define GTM_BITMAPSET_SIZE(nwords)	\
+	(offsetof(gtm_Bitmapset, words) + (nwords) * sizeof(gtm_bitmapword))
+
+static const uint8 gtm_number_of_ones[256] = {
+	0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+	1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+	1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+	1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+	2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+	1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+	2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+	2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+	3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+	4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8
+};
+
+/*
+ *  * bms_copy - make a palloc'd copy of a bitmapset
+ *   */
+gtm_Bitmapset *
+gtm_bms_copy(const gtm_Bitmapset *a)
+{
+	gtm_Bitmapset  *result;
+	size_t		size;
+
+	if (a == NULL)
+		return NULL;
+	size = gtm_BITMAPSET_SIZE(a->nwords);
+	result = (gtm_Bitmapset *) palloc(size);
+	memcpy(result, a, size);
+	return result;
+}
+
+
+/*
+ * gtm_bms_make_singleton - build a bitmapset containing a single member
+ */
+gtm_Bitmapset *
+gtm_bms_make_singleton(int x)
+{
+	gtm_Bitmapset  *result;
+	int			wordnum,
+				bitnum;
+
+	if (x < 0)
+		elog(ERROR, "negative bitmapset member not allowed");
+	wordnum = GTM_WORDNUM(x);
+	bitnum = GTM_BITNUM(x);
+	result = (gtm_Bitmapset *) palloc0(GTM_BITMAPSET_SIZE(wordnum + 1));
+	result->nwords = wordnum + 1;
+	result->words[wordnum] = ((gtm_bitmapword) 1 << bitnum);
+	return result;
+}
+
+/*
+ * gtm_bms_free - free a bitmapset
+ *
+ * Same as pfree except for allowing NULL input
+ */
+void
+gtm_bms_free(gtm_Bitmapset *a)
+{
+	if (a)
+		pfree(a);
+}
+
+/*
+ * gtm_bms_num_members - count members of set
+ */
+int
+gtm_bms_num_members(const gtm_Bitmapset *a)
+{
+	int			result = 0;
+	int			nwords;
+	int			wordnum;
+
+	if (a == NULL)
+		return 0;
+	nwords = a->nwords;
+	for (wordnum = 0; wordnum < nwords; wordnum++)
+	{
+		bitmapword	w = a->words[wordnum];
+
+		/* we assume here that bitmapword is an unsigned type */
+		while (w != 0)
+		{
+			result += number_of_ones[w & 255];
+			w >>= 8;
+		}
+	}
+	return result;
+}
+
+
+/*
+ * gtm_bms_add_member - add a specified member to set
+ *
+ * Input set is modified or recycled!
+ */
+gtm_Bitmapset *
+gmt_bms_add_member(gtm_Bitmapset *a, int x)
+{
+	int			wordnum,
+				bitnum;
+
+	if (x < 0)
+		elog(ERROR, "negative bitmapset member not allowed");
+	if (a == NULL)
+		return bms_make_singleton(x);
+	wordnum = WORDNUM(x);
+	bitnum = BITNUM(x);
+	if (wordnum >= a->nwords)
+	{
+		/* Slow path: make a larger set and union the input set into it */
+		gtm_Bitmapset  *result;
+		int			nwords;
+		int			i;
+
+		result = bms_make_singleton(x);
+		nwords = a->nwords;
+		for (i = 0; i < nwords; i++)
+			result->words[i] |= a->words[i];
+		pfree(a);
+		return result;
+	}
+	/* Fast path: x fits in existing set */
+	a->words[wordnum] |= ((bitmapword) 1 << bitnum);
+	return a;
+}
+
+/*
+ * gtm_bms_del_member - remove a specified member from set
+ *
+ * No error if x is not currently a member of set
+ *
+ * Input set is modified in-place!
+ */
+gtm_Bitmapset *
+gtm_bms_del_member(gtm_Bitmapset *a, int x)
+{
+	int			wordnum,
+				bitnum;
+
+	if (x < 0)
+		elog(ERROR, "negative bitmapset member not allowed");
+	if (a == NULL)
+		return NULL;
+	wordnum = WORDNUM(x);
+	bitnum = BITNUM(x);
+	if (wordnum < a->nwords)
+		a->words[wordnum] &= ~((bitmapword) 1 << bitnum);
+	return a;
+}
+
+/*
+ * gtm_bms_is_empty - is a set empty?
+ *
+ */
+bool
+gtm_bms_is_empty(const gtm_Bitmapset *a)
+{
+	int         nwords;
+	int         wordnum;
+
+	if (a == NULL)
+		return true;
+	nwords = a->nwords;
+	for (wordnum = 0; wordnum < nwords; wordnum++)
+	{
+		bitmapword  w = a->words[wordnum];
+
+		if (w != 0)
+			return false;
+	}
+	return true;
+}
+
+/*
+ * gtm_bms_del_members - like bms_difference, but left input is recycled
+ */
+gtm_Bitmapset *
+gtm_bms_del_members(gtm_Bitmapset *a, const gtm_Bitmapset *b)
+{
+	int			shortlen;
+	int			i;
+
+	/* Handle cases where either input is NULL */
+	if (a == NULL)
+		return NULL;
+	if (b == NULL)
+		return a;
+	/* Remove b's bits from a; we need never copy */
+	shortlen = Min(a->nwords, b->nwords);
+	for (i = 0; i < shortlen; i++)
+		a->words[i] &= ~b->words[i];
+	return a;
+}

--- a/src/gtm/proxy/proxy_main.c
+++ b/src/gtm/proxy/proxy_main.c
@@ -30,6 +30,7 @@
 #include "gtm/elog.h"
 #include "gtm/memutils.h"
 #include "gtm/gtm_list.h"
+#include "gtm/gtm_bitmapset.h"
 #include "gtm/libpq.h"
 #include "gtm/libpq-be.h"
 #include "gtm/libpq-fe.h"

--- a/src/gtm/proxy/proxy_main.c
+++ b/src/gtm/proxy/proxy_main.c
@@ -1117,7 +1117,6 @@ GTMProxy_ThreadMain(void *argp)
 										   ALLOCSET_DEFAULT_MAXSIZE,
 										   false);
 
-
 	/*
 	 * Set up connection with the GTM server
 	 */

--- a/src/gtm/proxy/proxy_main.c
+++ b/src/gtm/proxy/proxy_main.c
@@ -2677,12 +2677,11 @@ GTMProxy_ProcessPendingCommands(GTMProxy_ThreadInfo *thrinfo)
 		elog(ERROR, "Some message can not be grouped together");
 	}
 
+	tmpset = gtm_bms_del_member(tmpset, MSG_BACKEND_DISCONNECT);
+
 	while((ii = gtm_bms_first_member(tmpset)) >= 0)
 	{
 		int res_index = 0;
-		if (ii == MSG_BACKEND_DISCONNECT) {
-			continue;
-		}
 		/*
 		 * Start a new group message and fill in the headers
 		 */
@@ -2853,7 +2852,7 @@ GTMProxy_ProcessPendingCommands(GTMProxy_ThreadInfo *thrinfo)
 
 
 			default:
-				elog(ERROR, "Unkown message type (%d)", ii);
+				elog(ERROR, "This message type (%d) can not be grouped together", ii);
 		}
 	}
 

--- a/src/gtm/proxy/proxy_main.c
+++ b/src/gtm/proxy/proxy_main.c
@@ -1117,7 +1117,6 @@ GTMProxy_ThreadMain(void *argp)
 										   ALLOCSET_DEFAULT_MAXSIZE,
 										   false);
 
-	MemoryContextSwitchTo(TopMemoryContext);
 
 	/*
 	 * Set up connection with the GTM server

--- a/src/gtm/proxy/proxy_main.c
+++ b/src/gtm/proxy/proxy_main.c
@@ -1526,7 +1526,7 @@ setjmp_again:
 		gtm_list_free_deep(thrinfo->thr_processed_commands);
 		thrinfo->thr_processed_commands = gtm_NIL;
 		gtm_bms_free(thrinfo->pending_msg_type_set);
-        thrinfo->pending_msg_type_set = gtm_NIL;
+		thrinfo->pending_msg_type_set = NULL;
 		/*
 		 * Now clean up disconnected connections
 		 */

--- a/src/gtm/proxy/proxy_main.c
+++ b/src/gtm/proxy/proxy_main.c
@@ -1117,6 +1117,8 @@ GTMProxy_ThreadMain(void *argp)
 										   ALLOCSET_DEFAULT_MAXSIZE,
 										   false);
 
+	MemoryContextSwitchTo(TopMemoryContext);
+
 	/*
 	 * Set up connection with the GTM server
 	 */
@@ -1147,6 +1149,16 @@ GTMProxy_ThreadMain(void *argp)
 		thrinfo->thr_qtype[ii] = 0;
 		initStringInfo(&(thrinfo->thr_inBufData[ii]));
 	}
+
+	thrinfo->pending_msg_type_mask = gtm_bms_make_singleton(MSG_TXN_BEGIN_GETGXID);
+	thrinfo->pending_msg_type_mask = gtm_bms_add_member(thrinfo->pending_msg_type_mask, 
+														MSG_TXN_COMMIT);
+	thrinfo->pending_msg_type_mask = gtm_bms_add_member(thrinfo->pending_msg_type_mask,
+														MSG_TXN_ROLLBACK);
+	thrinfo->pending_msg_type_mask = gtm_bms_add_member(thrinfo->pending_msg_type_mask,
+														MSG_SNAPSHOT_GET);
+	thrinfo->pending_msg_type_mask = gtm_bms_add_member(thrinfo->pending_msg_type_mask,
+														MSG_BACKEND_DISCONNECT);
 
 	/*
 	 * If an exception is encountered, processing resumes here so we abort the
@@ -1239,6 +1251,7 @@ GTMProxy_ThreadMain(void *argp)
 		MemoryContextSwitchTo(MessageContext);
 		MemoryContextResetAndDeleteChildren(MessageContext);
 
+		thrinfo->pending_msg_type_set = gtm_bms_make_singleton(MSG_TYPE_COUNT);;
 		/*
 		 * The following block should be skipped at the first turn.
 		 */
@@ -1375,6 +1388,9 @@ setjmp_again:
 		 */
 		resetStringInfo(&input_message);
 
+		// Rest the pending_msg_type_set
+		gtm_bms_reset(thrinfo->pending_msg_type_set);
+
 		/*
 		 * Now, read command from each of the connections that has some data to
 		 * be read.
@@ -1509,7 +1525,8 @@ setjmp_again:
 
 		gtm_list_free_deep(thrinfo->thr_processed_commands);
 		thrinfo->thr_processed_commands = gtm_NIL;
-
+		gtm_bms_free(thrinfo->pending_msg_type_set);
+        thrinfo->pending_msg_type_set = gtm_NIL;
 		/*
 		 * Now clean up disconnected connections
 		 */
@@ -2509,6 +2526,7 @@ static void
 GTMProxy_CommandPending(GTMProxy_ConnectionInfo *conninfo, GTM_MessageType mtype,
 		GTMProxy_CommandData cmd_data)
 {
+	Assert(mtype != MSG_TYPE_COUNT);
 	GTMProxy_CommandInfo *cmdinfo;
 	GTMProxy_ThreadInfo *thrinfo = GetMyThreadInfo;
 
@@ -2521,6 +2539,7 @@ GTMProxy_CommandPending(GTMProxy_ConnectionInfo *conninfo, GTM_MessageType mtype
 	cmdinfo->ci_res_index = 0;
 	cmdinfo->ci_data = cmd_data;
 	thrinfo->thr_pending_commands[mtype] = gtm_lappend(thrinfo->thr_pending_commands[mtype], cmdinfo);
+	gtm_bms_add_member(thrinfo->pending_msg_type_set, mtype);
 
 	return;
 }
@@ -2651,16 +2670,19 @@ GTMProxy_ProcessPendingCommands(GTMProxy_ThreadInfo *thrinfo)
 	GTM_ProxyMsgHeader proxyhdr;
 	GTM_Conn *gtm_conn = thrinfo->thr_gtm_conn;
 	gtm_ListCell *elem = NULL;
+	gtm_Bitmapset *tmpset = gtm_bms_copy(thrinfo->pending_msg_type_set);
 
-	for (ii = 0; ii < MSG_TYPE_COUNT; ii++)
+	gtm_bms_del_members(thrinfo->pending_msg_type_set, thrinfo->pending_msg_type_mask);
+	if (!gtm_bms_is_empty(thrinfo->pending_msg_type_set)) {
+		elog(ERROR, "Some message can not be grouped together");
+	}
+
+	while((ii = gtm_bms_first_member(tmpset)) >= 0)
 	{
 		int res_index = 0;
-
-		/* We process backend disconnects last! */
-		if (ii == MSG_BACKEND_DISCONNECT ||
-				gtm_list_length(thrinfo->thr_pending_commands[ii]) == 0)
+		if (ii == MSG_BACKEND_DISCONNECT) {
 			continue;
-
+		}
 		/*
 		 * Start a new group message and fill in the headers
 		 */
@@ -2831,9 +2853,10 @@ GTMProxy_ProcessPendingCommands(GTMProxy_ThreadInfo *thrinfo)
 
 
 			default:
-				elog(ERROR, "This message type (%d) can not be grouped together", ii);
+				elog(ERROR, "Unkown message type (%d)", ii);
 		}
 	}
+
 	/* Process backend disconnect messages now */
 	gtm_foreach (elem, thrinfo->thr_pending_commands[MSG_BACKEND_DISCONNECT])
 	{
@@ -2843,6 +2866,8 @@ GTMProxy_ProcessPendingCommands(GTMProxy_ThreadInfo *thrinfo)
 		cmdinfo = (GTMProxy_CommandInfo *)gtm_lfirst(elem);
 		GTMProxy_HandleDisconnect(cmdinfo->ci_conn, gtm_conn);
 	}
+
+	gtm_bms_free(tmpset);
 }
 
 /*

--- a/src/include/gtm/gtm_bitmapset.h
+++ b/src/include/gtm/gtm_bitmapset.h
@@ -1,0 +1,28 @@
+#ifndef GTM_BITMAPSET_H
+#define GTM_BITMAPSET_H
+
+/*
+ *  * Data representation
+ *   */
+
+/* The unit size can be adjusted by changing these three declarations: */
+#define GTM_BITS_PER_BITMAPWORD 32
+typedef uint32 gtm_bitmapword;      /* must be an unsigned type */
+typedef int32 gtm_signedbitmapword; /* must be the matching signed type */
+
+typedef struct gtm_Bitmapset
+{
+    int         nwords;         /* number of words in array */
+    bitmapword  words[1];       /* really [nwords] */
+} gtm_Bitmapset;                    /* VARIABLE LENGTH STRUCT */
+
+extern gtm_Bitmapset *gtm_bms_copy(const gtm_Bitmapset *a);
+extern gtm_Bitmapset *gtm_bms_make_singleton(int x);
+extern void gtm_bms_free(gtm_Bitmapset *a);
+extern int  gtm_bms_num_members(const gtm_Bitmapset *a);
+extern gtm_Bitmapset *gtm_bms_add_member(gtm_Bitmapset *a, int x);
+extern gtm_Bitmapset *gtm_bms_del_member(gtm_Bitmapset *a, int x);
+extern gtm_Bitmapset *gmt_bms_del_members(gtm_Bitmapset *a, const gtm_Bitmapset *b);
+extern bool gtm_bms_is_empty(const gtm_Bitmapset *a);
+
+#endif   /* GTM_BITMAPSET_H */

--- a/src/include/gtm/gtm_bitmapset.h
+++ b/src/include/gtm/gtm_bitmapset.h
@@ -13,7 +13,7 @@ typedef int32 gtm_signedbitmapword; /* must be the matching signed type */
 typedef struct gtm_Bitmapset
 {
     int         nwords;         /* number of words in array */
-    bitmapword  words[1];       /* really [nwords] */
+    gtm_bitmapword  words[1];       /* really [nwords] */
 } gtm_Bitmapset;                    /* VARIABLE LENGTH STRUCT */
 
 extern gtm_Bitmapset *gtm_bms_copy(const gtm_Bitmapset *a);
@@ -22,7 +22,9 @@ extern void gtm_bms_free(gtm_Bitmapset *a);
 extern int  gtm_bms_num_members(const gtm_Bitmapset *a);
 extern gtm_Bitmapset *gtm_bms_add_member(gtm_Bitmapset *a, int x);
 extern gtm_Bitmapset *gtm_bms_del_member(gtm_Bitmapset *a, int x);
-extern gtm_Bitmapset *gmt_bms_del_members(gtm_Bitmapset *a, const gtm_Bitmapset *b);
+extern gtm_Bitmapset *gtm_bms_del_members(gtm_Bitmapset *a, const gtm_Bitmapset *b);
 extern bool gtm_bms_is_empty(const gtm_Bitmapset *a);
+extern int  gtm_bms_first_member(gtm_Bitmapset *a);
+extern void  gtm_bms_reset(gtm_Bitmapset *a);
 
 #endif   /* GTM_BITMAPSET_H */

--- a/src/include/gtm/gtm_proxy.h
+++ b/src/include/gtm/gtm_proxy.h
@@ -23,6 +23,7 @@
 #include "gtm/gtm_conn.h"
 #include "gtm/elog.h"
 #include "gtm/gtm_list.h"
+#include "gtm/gtm_bitmapset.h"
 #include "gtm/gtm_msg.h"
 #include "gtm/libpq-fe.h"
 
@@ -121,6 +122,9 @@ typedef struct GTMProxy_ThreadInfo
 
 	gtm_List 					*thr_processed_commands;
 	gtm_List 					*thr_pending_commands[MSG_TYPE_COUNT];
+
+	gtm_Bitmapset			*pending_msg_type_set;
+	gtm_Bitmapset			*pending_msg_type_mask;
 
 	GTM_Conn				*thr_gtm_conn;		/* Connection to GTM */
 


### PR DESCRIPTION
Adding bitmapset (borrowed from pg) as utility to gtm. 
Adding 2 bitmapset to struct GTMProxy_ThreadInfo: one for the message types added to the thr_pending_commands, and another as the targeted message type need to proxy. 
When adding a command to  thr_pending_commands, add the message type to bitmapset. 
In GTMProxy_ProcessPendingCommands() , get the message type from bitmapset and handle them one by one.
