### PR TITLE
ticket to issue 119

### DIFF
--- a/src/bin/gtm_ctl/gtm_ctl.c
+++ b/src/bin/gtm_ctl/gtm_ctl.c
@@ -292,7 +292,7 @@ start_gtm(void)
 	strncat(gtm_app_path, gtm_app, MAXPGPATH - len - 1);
 
 	if (log_file != NULL)
-		len = snprintf(cmd, MAXPGPATH - 1, SYSTEMQUOTE "\"%s\" %s%s -l %s &" SYSTEMQUOTE,
+		len = snprintf(cmd, MAXPGPATH - 1, SYSTEMQUOTE "\"%s\" %s%s >> \"%s\"  2>&1 &" SYSTEMQUOTE,
 				 gtm_app_path, gtmdata_opt, gtm_opts, log_file);
 	else
 		len = snprintf(cmd, MAXPGPATH - 1, SYSTEMQUOTE "\"%s\" %s%s < \"%s\" 2>&1 &" SYSTEMQUOTE,
@@ -304,10 +304,7 @@ start_gtm(void)
 		exit(1);
 	}
 
-	if (log_file)
-		return (RunAsDaemon(cmd));
-	else
-		return system(cmd);
+	return system(cmd);
 }
 
 /*

--- a/src/gtm/config/gtm_opt_handler.c
+++ b/src/gtm/config/gtm_opt_handler.c
@@ -1405,6 +1405,7 @@ SelectConfigFiles(const char *userDoption, const char *progname)
 		configdir = make_absolute_path(userDoption);
 	else
 		configdir = NULL;
+
 	/*
 	 * Find the configuration file: if config_file was specified on the
 	 * command line, use it, else use configdir/postgresql.conf.  In any case

--- a/src/gtm/config/gtm_opt_handler.c
+++ b/src/gtm/config/gtm_opt_handler.c
@@ -344,19 +344,19 @@ cleanup_list:
 		free(cvc);
 
 	if (error)
-    {
-        /* During startup, any error is fatal */
-        if (context == GTMC_STARTUP)
-            ereport(ERROR,
-                    (0,
-                     errmsg("configuration file \"%s\" contains errors",
-                            GTMConfigFileName)));
+	{
+		/* During startup, any error is fatal */
+		if (context == GTMC_STARTUP)
+			ereport(ERROR,
+					(0,
+					errmsg("configuration file \"%s\" contains errors",
+							GTMConfigFileName)));
         else
-            ereport(elevel,
-                    (0,
-                     errmsg("configuration file \"%s\" contains errors; no changes were applied",
-                            GTMConfigFileName)));
-    }
+			ereport(elevel,
+					(0,
+					errmsg("configuration file \"%s\" contains errors; no changes were applied",
+							GTMConfigFileName)));
+	}
 }
 
 /*
@@ -1405,7 +1405,6 @@ SelectConfigFiles(const char *userDoption, const char *progname)
 		configdir = make_absolute_path(userDoption);
 	else
 		configdir = NULL;
-	
 	/*
 	 * Find the configuration file: if config_file was specified on the
 	 * command line, use it, else use configdir/postgresql.conf.  In any case
@@ -2697,7 +2696,7 @@ void
 SetConfigOption(const char *name, const char *value,
 				GtmOptContext context, GtmOptSource source)
 {
-	return (void)set_config_option(name, value, context, source,
+	(void)set_config_option(name, value, context, source,
 							 true);
 }
 

--- a/src/gtm/config/gtm_opt_handler.c
+++ b/src/gtm/config/gtm_opt_handler.c
@@ -351,7 +351,7 @@ cleanup_list:
 					(0,
 					errmsg("configuration file \"%s\" contains errors",
 							GTMConfigFileName)));
-        else
+		else
 			ereport(elevel,
 					(0,
 					errmsg("configuration file \"%s\" contains errors; no changes were applied",

--- a/src/gtm/config/gtm_opt_handler.c
+++ b/src/gtm/config/gtm_opt_handler.c
@@ -2696,7 +2696,7 @@ void
 SetConfigOption(const char *name, const char *value,
 				GtmOptContext context, GtmOptSource source)
 {
-	(void)set_config_option(name, value, context, source,
+	(void) set_config_option(name, value, context, source,
 							 true);
 }
 

--- a/src/gtm/main/main.c
+++ b/src/gtm/main/main.c
@@ -332,11 +332,11 @@ main(int argc, char *argv[])
 	isStartUp = true;
 
 	/*
-	 * At first, initialize options.  Also moved something from BaseInit() here.
+	 * At first, initialize options, main thread and TopMostMemoryContext.
 	 */
 	InitializeGTMOptions();
-
 	BaseInit1();
+
 	/*
 	 * Catch standard options before doing much else
 	 */

--- a/src/gtm/main/main.c
+++ b/src/gtm/main/main.c
@@ -169,7 +169,7 @@ MainThreadInit()
 }
 
 static void
-BaseInit()
+BaseInit1()
 {
 	GTM_ThreadInfo *thrinfo;
 
@@ -179,6 +179,20 @@ BaseInit()
 
 	MemoryContextInit();
 
+	/*
+	 * The memory context is now set up.
+	 * Add the thrinfo structure in the global array
+	 */
+	if (GTM_ThreadAdd(thrinfo) == -1)
+	{
+		fprintf(stderr, "GTM_ThreadAdd for main thread failed: %d", errno);
+		fflush(stdout);
+		fflush(stderr);
+	}
+}
+static void
+BaseInit2()
+{
 	checkDataDir();
 	SetDataDir();
 	ChangeToDataDir();
@@ -198,18 +212,6 @@ BaseInit()
 
 	GTM_InitTxnManager();
 	GTM_InitSeqManager();
-
-
-	/*
-	 * The memory context is now set up.
-	 * Add the thrinfo structure in the global array
-	 */
-	if (GTM_ThreadAdd(thrinfo) == -1)
-	{
-		fprintf(stderr, "GTM_ThreadAdd for main thread failed: %d", errno);
-		fflush(stdout);
-		fflush(stderr);
-	}
 }
 
 static void
@@ -333,6 +335,8 @@ main(int argc, char *argv[])
 	 * At first, initialize options.  Also moved something from BaseInit() here.
 	 */
 	InitializeGTMOptions();
+
+	BaseInit1();
 	/*
 	 * Catch standard options before doing much else
 	 */
@@ -545,7 +549,7 @@ main(int argc, char *argv[])
 	 * Some basic initialization must happen before we do anything
 	 * useful
 	 */
-	BaseInit();
+	BaseInit2();
 
 	/*
 	 * Establish a connection between the active and standby.

--- a/src/gtm/proxy/proxy_main.c
+++ b/src/gtm/proxy/proxy_main.c
@@ -234,7 +234,7 @@ MainThreadInit()
 }
 
 static void
-BaseInit()
+BaseInit1()
 {
 	GTMProxy_ThreadInfo *thrinfo;
 
@@ -244,6 +244,21 @@ BaseInit()
 
 	MemoryContextInit();
 
+	/*
+	 * The memory context is now set up.
+	 * Add the thrinfo structure in the global array
+	 */
+	if (GTMProxy_ThreadAdd(thrinfo) == -1)
+	{
+		fprintf(stderr, "GTMProxy_ThreadAdd for main thread failed: %d", errno);
+		fflush(stdout);
+		fflush(stderr);
+	}
+}
+
+static void
+BaseInit2()
+{
 	checkDataDir();
 	SetDataDir();
 	ChangeToDataDir();
@@ -266,17 +281,6 @@ BaseInit()
 	RegisterProxy(false, false);
 
 	DebugFileOpen();
-
-	/*
-	 * The memory context is now set up.
-	 * Add the thrinfo structure in the global array
-	 */
-	if (GTMProxy_ThreadAdd(thrinfo) == -1)
-	{
-		fprintf(stderr, "GTMProxy_ThreadAdd for main thread failed: %d", errno);
-		fflush(stdout);
-		fflush(stderr);
-	}
 }
 
 static char *
@@ -583,6 +587,8 @@ main(int argc, char *argv[])
 	 */
 	InitializeGTMOptions();
 
+	BaseInit1();
+
 	/*
 	 * Catch standard options before doing much else
 	 */
@@ -804,7 +810,7 @@ main(int argc, char *argv[])
 	 * Some basic initialization must happen before we do anything
 	 * useful
 	 */
-	BaseInit();
+	BaseInit2();
 
 	elog(LOG, "Starting GTM proxy at (%s:%d)", ListenAddresses, GTMProxyPortNumber);
 

--- a/src/gtm/proxy/proxy_main.c
+++ b/src/gtm/proxy/proxy_main.c
@@ -583,10 +583,9 @@ main(int argc, char *argv[])
 	isStartUp = true;
 
 	/*
-	 * At first, initialize options.   Also moved something from BaseInit() here.
+	 * At first, initialize options, main thread and  TopMostMemoryContext.
 	 */
 	InitializeGTMOptions();
-
 	BaseInit1();
 
 	/*

--- a/src/gtm/proxy/proxy_main.c
+++ b/src/gtm/proxy/proxy_main.c
@@ -583,7 +583,7 @@ main(int argc, char *argv[])
 	isStartUp = true;
 
 	/*
-	 * At first, initialize options, main thread and  TopMostMemoryContext.
+	 * At first, initialize options, main thread and TopMostMemoryContext.
 	 */
 	InitializeGTMOptions();
 	BaseInit1();


### PR DESCRIPTION
1 For gtm and gtm_proxy, need to initialize memcontext as early as possible. Just like what  postmaster does
2, After initialization of Memcontext, use pmalloc and pfree to manage memory
3, For gtm_ctl, we need to redirect stderr and stdout to logfile if user specified it, just follows pg_ctl. So user can get error message in logfile if find error when initialize gtm or gtm_proxy.
