### PR TITLE
Fix #323 Solve the problems of missing html documents: add-node.html,remove-node.html,etc.

### DIFF
--- a/doc-xc/src/sgml/filelist.sgmlin
+++ b/doc-xc/src/sgml/filelist.sgmlin
@@ -58,6 +58,8 @@
 <!ENTITY config        SYSTEM "config.sgml">
 <!ENTITY user-manag    SYSTEM "user-manag.sgml">
 <!ENTITY wal           SYSTEM "wal.sgml">
+<!ENTITY add-node      SYSTEM "add-node.sgml">
+<!ENTITY remove-node   SYSTEM "remove-node.sgml">
 
 <!-- programmer's guide -->
 <!ENTITY bgworker   SYSTEM "bgworker.sgml">

--- a/doc-xc/src/sgml/postgres.sgmlin
+++ b/doc-xc/src/sgml/postgres.sgmlin
@@ -187,6 +187,8 @@
   &diskusage;
   &wal;
   &regress;
+  &add-node;
+  &remove-node;
 
  </part>
 


### PR DESCRIPTION
In v1.1,  you can see : 

```
III. Server Administration
15. Installation from Source Code
...
...
29. Regression Tests
30. Adding a New Node
31. Removing an Existing Node
```

but in v1.2,  "30. Adding a New Node" and "31. Removing and Existing Node" is missing:

```
III. Server Administration
15. Installation from Source Code
...
...
29. Regression Tests
```

when you generate html document:

```
cd doc-xc
make html
```

then you enter doc-xc/src/sgml/html, you can not find add-node.html,remove-node.html.
