### PR TITLE
Don't FQS when grouping by no distribution column

### DIFF
--- a/src/backend/optimizer/util/pgxcship.c
+++ b/src/backend/optimizer/util/pgxcship.c
@@ -995,6 +995,12 @@ pgxc_shippability_walker(Node *node, Shippability_context *sc_context)
 				!pgxc_query_has_distcolgrouping(query, sc_context->sc_exec_nodes))
 				pgxc_set_shippability_reason(sc_context, SS_NEED_SINGLENODE);
 
+                         /* Grouping by non distribution column can not be FQS*/
+                         if (query->groupClause != NULL &&  
+                               sc_context->sc_exec_nodes &&
+                               !pgxc_query_has_distcolgrouping(query, sc_context->sc_exec_nodes))
+                               pgxc_set_shippability_reason(sc_context, SS_NEED_SINGLENODE);
+
 			/*
 			 * If distribution column of any relation is present in the distinct
 			 * clause, values for that column across nodes will differ, thus two

--- a/src/test/regress/expected/xc_FQS.out
+++ b/src/test/regress/expected/xc_FQS.out
@@ -176,12 +176,14 @@ select val, val2 from tab1_rr where val2 = 8 group by val, val2;
 (1 row)
 
 explain (costs off, verbose on, nodes off) select val, val2 from tab1_rr where val2 = 8 group by val, val2;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Data Node Scan on "__REMOTE_FQS_QUERY__"
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ HashAggregate
    Output: tab1_rr.val, tab1_rr.val2
-   Remote query: SELECT val, val2 FROM public.tab1_rr WHERE (val2 = 8) GROUP BY val, val2
-(3 rows)
+   ->  Data Node Scan on "__REMOTE_GROUP_QUERY__"
+         Output: tab1_rr.val, tab1_rr.val2
+         Remote query: SELECT val, val2 FROM ONLY public.tab1_rr WHERE (val2 = 8) GROUP BY 1, 2
+(5 rows)
 
 -- should not get FQSed because of presence of aggregates and HAVING clause,
 select sum(val) from tab1_rr where val2 = 2 group by val2 having sum(val) > 1;


### PR DESCRIPTION
When grouping by non distribution fields we get duplicates.

create table t1 (
field1 boolean,
field2 numeric)
distribute by hash(field2);
insert into t1 values (true,1);
insert into t1 values (false,1);
insert into t1 values (true,2);
insert into t1 values (false,2);
insert into t1 values (true,3);
insert into t1 values (false,3);
insert into t1 values (true,4);
insert into t1 values (false,4);
insert into t1 values (true,5);
insert into t1 values (false,5);
insert into t1 values (true,6);
insert into t1 values (false,6);

select field1 from t1 group by field1;

We get 
T
F
T
F

But was the expected value 
T
F
