### PR TITLE
In datanodes, the time of SQL execution is wrong

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -842,7 +842,10 @@ GetCurrentStatementStartTimestamp(void)
 	 * clock. This permits to follow the GTM timeline in the cluster.
 	 */
 #ifdef PGXC
-	return stmtStartTimestamp + GTMdeltaTimestamp;
+	if (IS_PGXC_DATANODE && IsConnFromCoord())
+	return stmtStartTimestamp;
+	else
+	return stmtStartTimestamp + GTMdeltaTimestamp
 #else
 	return stmtStartTimestamp;
 #endif


### PR DESCRIPTION
In coordinators, should contain the time of running in GTM, but in datanodes it should not be contained.
In fact, if you set the  parameter of "log_min_duration_statement" in the file of "postgres.conf", then you can see  the execution time of SQL. But you will find the time in datanodes is longer than in coordinators. It is obviously not true.
