### PR TITLE
fix bug for gtm_proxy deadlock

### DIFF
--- a/src/gtm/proxy/proxy_main.c
+++ b/src/gtm/proxy/proxy_main.c
@@ -140,7 +140,7 @@ static GTMProxy_ConnectionInfo *GTMProxy_GetConnInfo(GTMProxy_ThreadInfo *thrinf
 													 GTMProxy_ConnID con_id);
 static int GTMProxy_GetConnInfoIndex(GTMProxy_ThreadInfo *thrinfo, GTMProxy_ConnID con_id);
 static int ReadCommand(GTMProxy_ConnectionInfo *conninfo, StringInfo inBuf);
-static void GTMProxy_HandshakeConnection(GTMProxy_ConnectionInfo *conninfo);
+static void GTMProxy_HandshakeConnection(GTMProxy_ConnectionInfo *conninfo,GTM_MutexLock *lock);
 static void GTMProxy_HandleDisconnect(GTMProxy_ConnectionInfo *conninfo, GTM_Conn *gtm_conn);
 
 static void GTMProxy_ProxyCommand(GTMProxy_ConnectionInfo *conninfo,
@@ -1295,7 +1295,7 @@ GTMProxy_ThreadMain(void *argp)
 					 * If this is a newly added connection, complete the handshake
 					 */
 					if (!conninfo->con_authenticated)
-						GTMProxy_HandshakeConnection(conninfo);
+						GTMProxy_HandshakeConnection(conninfo,&thrinfo->thr_lock);
 
 					thrinfo->thr_poll_fds[ii].fd = conninfo->con_port->sock;
 					thrinfo->thr_poll_fds[ii].events = POLLIN;
@@ -2543,7 +2543,7 @@ GTMProxy_RegisterPGXCNode(GTMProxy_ConnectionInfo *conninfo,
 }
 
 static void
-GTMProxy_HandshakeConnection(GTMProxy_ConnectionInfo *conninfo)
+GTMProxy_HandshakeConnection(GTMProxy_ConnectionInfo *conninfo,GTM_MutexLock *lock)
 {
 	/*
 	 * We expect a startup message at the very start. The message type is
@@ -2557,10 +2557,20 @@ GTMProxy_HandshakeConnection(GTMProxy_ConnectionInfo *conninfo)
 	startup_type = pq_getbyte(conninfo->con_port);
 
 	if (startup_type != 'A')
+        {
+		GTM_MutexLockRelease(lock); 
+		if (conninfo->con_port->sock >= 0)
+                {
+                close(conninfo->con_port->sock);
+                conninfo->con_port->sock = -1;
+                }
+                conninfo->con_disconnected=true;
+		elog(WARNING, "Expecting a startup message, but received %c.\n", startup_type);
 		ereport(ERROR,
 				(EPROTO,
 				 errmsg("Expecting a startup message, but received %c",
 					 startup_type)));
+        } 
 
 	initStringInfo(&inBuf);
 
@@ -2569,10 +2579,23 @@ GTMProxy_HandshakeConnection(GTMProxy_ConnectionInfo *conninfo)
 	 * after the type code; we can read the message contents independently of
 	 * the type.
 	 */
+        Disable_Longjmp(); 
 	if (pq_getmessage(conninfo->con_port, &inBuf, 0))
+        {
+	        Enable_Longjmp();
+                GTM_MutexLockRelease(lock); 
+		if (conninfo->con_port->sock >= 0)
+                {
+                close(conninfo->con_port->sock);
+                conninfo->con_port->sock = -1;
+                }
+                conninfo->con_disconnected=true; 	
+		elog(WARNING, "Expecting PGXC Node ID, but received EOF.\n");
 		ereport(ERROR,
 				(EPROTO,
 				 errmsg("Expecting PGXC Node ID, but received EOF")));
+        } 
+	Enable_Longjmp();
 
 	memcpy(&sp,
 		   pq_getmsgbytes(&inBuf, sizeof (GTM_StartupPacket)),


### PR DESCRIPTION
Hi koichi,

 I found a bug about GTM_PRoxy, Now,I have fix this bug. If any problem. Please let me know.

In my production environment, Sometimes, DB can not process any query. when  i run any query, Session will be hang on this query.
after I restart a gtm_proxy.  Everything is ok. About this bug,  it is very hard to recreate it. and I also can not debug it in production environment.  About log,I also did not found any error message.

Now I have fixed this bug. Please review it. If any problem. Please let me know it.

My analysis is as follows：
       In GTMProxy_HandshakeConnection, if startup_type != 'A', By the "ereport", it will longjump to   "if (sigsetjmp(local_sigjmp_buf, 1) != 0) in function GTMProxy_ThreadMain".
this will lead gtm_proxy got lock(GTM_MutexLockAcquire(&thrinfo->thr_lock);) twice.
firsttime. before function GTMProxy_HandshakeConnection, we got lock &thrinfo->thr_lock.
but if longjump in GTMProxy_HandshakeConnection. we will got this lock second time. and work thread will hold on this lock.

```
* Thread Loop
 *-------------------------------------------------------------
 */
for (;;)
{
    gtm_ListCell *elem = NULL;
    GTM_Result *res = NULL;

    /*
     * Release storage left over from prior query cycle, and create a new
     * query input buffer in the cleared MessageContext.
     */
    MemoryContextSwitchTo(MessageContext);
    MemoryContextResetAndDeleteChildren(MessageContext);

    /*
     * The following block should be skipped at the first turn.
     */
    if (!first_turn)
    {
        /*
         * Check if there are any changes to the connection array assigned to
         * this thread. If so, we need to rebuild the fd array.
         */
        GTM_MutexLockAcquire(&thrinfo->thr_lock);
```

If work thread got lock (&thrinfo->thr_lock) twice, If we got new request to gtm_proxy. the main thread will try to 
get this lock. finaly, the main thread and work thread will be deadlock.

GTMProxy_ThreadInfo *
GTMProxy_ThreadAddConnection(GTMProxy_ConnectionInfo _conninfo)
{/_
     \* Lock the threadninfo structure to safely add the new connection to the
     \* thread structure. The thread will see the connection when it queries the
     \* socket descriptor in the next cycle
     */
    GTM_MutexLockAcquire(&thrinfo->thr_lock);

}

Node, If enable_longjump.then ereport will nod issue any error message. So i add elog to report some warning message.

You can recreate this bug with gdb (change startup_type ='B' in function GTMProxy_HandshakeConnection).

then gtm_proxy will deadlock,and BT about work thread and main thread as follows:

work thread 
(gdb) info threads
  2 Thread 0x7fa6f5ef9700 (LWP 7076)  0x0000003f61a0e264 in __lll_lock_wait () from /lib64/libpthread.so.0
- 1 Thread 0x7fa6f6109700 (LWP 7073)  0x0000003f61a0e264 in __lll_lock_wait () from /lib64/libpthread.so.0
  (gdb) thread 2
  [Switching to thread 2 (Thread 0x7fa6f5ef9700 (LWP 7076))]#0  0x0000003f61a0e264 in __lll_lock_wait () from /lib64/libpthread.so.0
  (gdb) bt
  #0  0x0000003f61a0e264 in __lll_lock_wait () from /lib64/libpthread.so.0
  #1  0x0000003f61a09508 in _L_lock_854 () from /lib64/libpthread.so.0
  #2  0x0000003f61a093d7 in pthread_mutex_lock () from /lib64/libpthread.so.0
  #3  0x000000000040c5bc in GTM_MutexLockAcquire (lock=0x16de488) at gtm_lock.c:135
  #4  0x0000000000422fe9 in GTMProxy_ThreadMain (argp=0x16ddd40) at proxy_main.c:1315
  #5  0x0000000000428671 in GTMProxy_ThreadMainWrapper (argp=0x16ddd40) at proxy_thread.c:319
  #6  0x0000003f61a079d1 in start_thread () from /lib64/libpthread.so.0
  #7  0x000000395c8e89dd in clone () from /lib64/libc.so.6

main thread

(gdb) BT
#0  0x0000003f61a0e264 in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x0000003f61a09508 in _L_lock_854 () from /lib64/libpthread.so.0
#2  0x0000003f61a093d7 in pthread_mutex_lock () from /lib64/libpthread.so.0
#3  0x000000000040c5bc in GTM_MutexLockAcquire (lock=0x16de488) at gtm_lock.c:135
#4  0x0000000000428769 in GTMProxy_ThreadAddConnection (conninfo=0x16cc870) at proxy_thread.c:367
#5  0x000000000042399c in GTMProxyAddConnection (port=0x1709260) at proxy_main.c:1620
#6  0x0000000000422b1e in ServerLoop () at proxy_main.c:1112
#7  0x00000000004227ce in main (argc=3, argv=0x7fff29e05a88) at proxy_main.c:954
